### PR TITLE
fix: backward compatible runtime env vars for client plugins

### DIFF
--- a/src/runtime/nitro/renderer.ts
+++ b/src/runtime/nitro/renderer.ts
@@ -90,7 +90,7 @@ export default eventHandler(async (event) => {
     event,
     req: event.req,
     res: event.res,
-    runtimeConfig: { private: config, public: { public: config.public, app: config.app } },
+    runtimeConfig: { private: config, public: { ...config.public, public: config.public, app: config.app } },
     noSSR: event.req.headers['x-nuxt-no-ssr'],
 
     error: ssrError,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue



### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

allows access env vars in bridge via $store in plugins on client

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

